### PR TITLE
feat: don't add new-pr label to backports or some prefixes

### DIFF
--- a/src/24-hour-rule/index.ts
+++ b/src/24-hour-rule/index.ts
@@ -1,18 +1,16 @@
 import { Application } from 'probot';
 
-import { NEW_PR_LABEL, MINIMUM_OPEN_TIME, BACKPORT_LABEL } from '../constants';
+import { NEW_PR_LABEL, MINIMUM_OPEN_TIME, EXCLUDE_LABELS, EXCLUDE_PREFIXES } from '../constants';
 
 const CHECK_INTERVAL = 1000 * 60;
 
 export function setUp24HourRule(probot: Application) {
   probot.on(['pull_request.opened', 'pull_request.unlabeled'], async context => {
     const pr = context.payload.pull_request;
-    const excludedLabels = [NEW_PR_LABEL, BACKPORT_LABEL];
-    const excludedPrefixes = ['build', 'ci'];
 
     const prefix = pr.title.split(':')[0];
-    const hasExcludedLabel = pr.labels.some((l: any) => excludedLabels.includes(l.name));
-    if (excludedPrefixes.includes(prefix) || hasExcludedLabel) return;
+    const hasExcludedLabel = pr.labels.some((l: any) => EXCLUDE_LABELS.includes(l.name));
+    if (EXCLUDE_PREFIXES.includes(prefix) || hasExcludedLabel) return;
 
     probot.log(
       'received PR:',

--- a/src/24-hour-rule/index.ts
+++ b/src/24-hour-rule/index.ts
@@ -7,12 +7,12 @@ const CHECK_INTERVAL = 1000 * 60;
 export function setUp24HourRule(probot: Application) {
   probot.on(['pull_request.opened', 'pull_request.unlabeled'], async context => {
     const pr = context.payload.pull_request;
-    if (
-      pr.labels.some((l: any) => {
-        l.name === NEW_PR_LABEL || l.name === BACKPORT_LABEL;
-      })
-    )
-      return;
+    const excludedLabels = [NEW_PR_LABEL, BACKPORT_LABEL];
+    const excludedPrefixes = ['build', 'ci'];
+
+    const prefix = pr.title.split(':')[0];
+    const hasExcludedLabel = pr.labels.some((l: any) => excludedLabels.includes(l.name));
+    if (excludedPrefixes.includes(prefix) || hasExcludedLabel) return;
 
     probot.log(
       'received PR:',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,3 +16,6 @@ export const NEEDS_REPRO_LABEL = 'blocked/needs-repro ❌';
 export const PLATFORM_MAC = 'platform/macOS';
 export const PLATFORM_WIN = 'platform/windows';
 export const PLATFORM_LINUX = 'platform/linux';
+
+export const EXCLUDE_LABELS = [NEW_PR_LABEL, BACKPORT_LABEL];
+export const EXCLUDE_PREFIXES = ['build', 'ci'];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,18 @@
 // 24 Hour Minimum Time
 export const MINIMUM_OPEN_TIME = 1000 * 60 * 60 * 24;
 
+// backport type labels
 export const NEW_PR_LABEL = 'new-pr 🌱';
+export const BACKPORT_LABEL = 'backport';
 export const BUG_LABEL = 'bug 🐞';
 export const ENHANCEMENT_LABEL = 'enhancement ✨';
 export const APP_STORE_LABEL = 'app-store';
 
+// missing information labels
 export const MISSING_INFO_LABEL = 'blocked/need-info ❌';
 export const NEEDS_REPRO_LABEL = 'blocked/needs-repro ❌';
 
+// platform labels
 export const PLATFORM_MAC = 'platform/macOS';
 export const PLATFORM_WIN = 'platform/windows';
 export const PLATFORM_LINUX = 'platform/linux';


### PR DESCRIPTION
Do not add the `'new-pr 🌱'` label to backports or to `build`/`ci` PRs.

cc @MarshallOfSound 