### PR TITLE
fix: feat backports should still be labeled

### DIFF
--- a/src/24-hour-rule/index.ts
+++ b/src/24-hour-rule/index.ts
@@ -14,8 +14,13 @@ const CHECK_INTERVAL = 1000 * 60 * 2;
 export function setUp24HourRule(probot: Application) {
   const shouldPRHaveLabel = (pr: WebhookPayloadWithRepository['pull_request']): boolean => {
     const prefix = pr.title.split(':')[0];
-    const hasExcludedLabel = pr.labels.some((l: any) => EXCLUDE_LABELS.includes(l.name));
-    if (EXCLUDE_PREFIXES.includes(prefix) || hasExcludedLabel) return false;
+    const backportMatch = pr.title.match(/[bB]ackport/);
+    const backportInTitle = backportMatch && backportMatch[0];
+    const hasExcludedLabel = pr.labels.some((l: any) => {
+      return EXCLUDE_LABELS.includes(l.name) || prefix !== 'feat';
+    });
+
+    if (EXCLUDE_PREFIXES.includes(prefix) || hasExcludedLabel || backportInTitle) return false;
 
     const created = new Date(pr.created_at).getTime();
     const now = Date.now();

--- a/src/24-hour-rule/index.ts
+++ b/src/24-hour-rule/index.ts
@@ -6,6 +6,7 @@ import {
   EXCLUDE_LABELS,
   EXCLUDE_PREFIXES,
   BACKPORT_LABEL,
+  EXCLUDE_USERS,
 } from '../constants';
 import { WebhookPayloadWithRepository, Context } from 'probot/lib/context';
 
@@ -20,7 +21,13 @@ export function setUp24HourRule(probot: Application) {
       return EXCLUDE_LABELS.includes(l.name) || prefix !== 'feat';
     });
 
-    if (EXCLUDE_PREFIXES.includes(prefix) || hasExcludedLabel || backportInTitle) return false;
+    if (
+      EXCLUDE_PREFIXES.includes(prefix) ||
+      hasExcludedLabel ||
+      backportInTitle ||
+      EXCLUDE_USERS.includes(pr.user.login)
+    )
+      return false;
 
     const created = new Date(pr.created_at).getTime();
     const now = Date.now();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,3 +19,4 @@ export const PLATFORM_LINUX = 'platform/linux';
 
 export const EXCLUDE_LABELS = [NEW_PR_LABEL, BACKPORT_LABEL];
 export const EXCLUDE_PREFIXES = ['build', 'ci'];
+export const EXCLUDE_USERS = ['roller-bot[bot]'];


### PR DESCRIPTION
Two fixes in this one:

1) Backports with the `feat` prefix should receive the `new-pr 🌱` label.
2) Cation now checks for the presence of `backport` somewhere in the PR title to mitigate the race condition with `trop` adding the `backport` label.

cc @MarshallOfSound 