### PR TITLE
feat: add update logic and fix misc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ const validTemplateMatch = async (context: Context): Promise<string | false> => 
     const issueParts = Object.keys(issueParser(issue.body));
     let optional: string[] = [];
 
+    // set optional fields for the template purportedly used
     switch (template.name) {
       case 'bug_report.md':
         optional = [
@@ -31,11 +32,18 @@ const validTemplateMatch = async (context: Context): Promise<string | false> => 
       case 'mac-app-store-private-api-rejection.md':
         optional = ['Additional Information'];
         break;
+      case 'security_report':
+        console.log('skipping security report');
+        break;
       default:
-      // fallthrough
+        console.log(`unrecognized template: '${template.name}'`);
+        break;
     }
 
+    // filter out non-required aspects of the issue template used
     const required: string[] = templateParts.filter(key => !optional.includes(key));
+
+    // determine template type by whether the issue's filled fields match a template
     if (utils.arrayContainsArray(issueParts, required)) {
       match = template.name;
     }

--- a/src/triageTemplate.ts
+++ b/src/triageTemplate.ts
@@ -72,7 +72,7 @@ const triagePlatform = async (platform: string, context: Context): Promise<Boole
 export const triageBugReport = async (
   components: Record<string, { raw: string }>,
   context: Context,
-  update: Boolean,
+  isUpdate: Boolean,
 ) => {
   let missingInfo: string[] = [];
 
@@ -88,21 +88,24 @@ export const triageBugReport = async (
   const actualBehavior = components['Actual Behavior'].raw;
   if (actualBehavior === '') missingInfo.push('Actual Behavior');
 
-  if (!update && missingInfo.length > 0) {
+  // comment on the pr notifying user of missing required fields
+  if (!isUpdate && missingInfo.length > 0) {
     await utils.notifyMissingInfo(context, missingInfo);
+    return;
+  }
+
+  // only edit labels if this isn't the issue's initial open event
+  if (isUpdate && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
+    await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
   } else {
-    if (update && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
-      await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
-    } else {
-      await utils.addIssueLabels(context, [BUG_LABEL]);
-    }
+    await utils.addIssueLabels(context, [BUG_LABEL]);
   }
 };
 
 export const triageFeatureRequest = async (
   components: Record<string, { raw: string }>,
   context: Context,
-  update: Boolean,
+  isUpdate: Boolean,
 ) => {
   let missingInfo: string[] = [];
 
@@ -115,21 +118,24 @@ export const triageFeatureRequest = async (
   const alternativeConsidered: string = components['Alternatives Considered'].raw;
   if (alternativeConsidered === '') missingInfo.push('Alternatives Considered');
 
-  if (!update && missingInfo.length > 0) {
+  // comment on the pr notifying user of missing required fields
+  if (!isUpdate && missingInfo.length > 0) {
     await utils.notifyMissingInfo(context, missingInfo);
+    return;
+  }
+
+  // only edit labels if this isn't the issue's initial open event
+  if (isUpdate && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
+    await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
   } else {
-    if (update && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
-      await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
-    } else {
-      await utils.addIssueLabels(context, [ENHANCEMENT_LABEL]);
-    }
+    await utils.addIssueLabels(context, [ENHANCEMENT_LABEL]);
   }
 };
 
 export const triageMASRejection = async (
   components: Record<string, { raw: string }>,
   context: Context,
-  update: Boolean,
+  isUpdate: Boolean,
 ) => {
   let missingInfo: string[] = [];
 
@@ -139,13 +145,16 @@ export const triageMASRejection = async (
   const rejectionEmail: string = components['Rejection Email'].raw;
   if (rejectionEmail === '') missingInfo.push('Rejection Email');
 
-  if (!update && missingInfo.length > 0) {
+  // comment on the pr notifying user of missing required fields
+  if (!isUpdate && missingInfo.length > 0) {
     await utils.notifyMissingInfo(context, missingInfo);
+    return;
+  }
+
+  // only edit labels if this isn't the issue's initial open event
+  if (isUpdate && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
+    await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
   } else {
-    if (update && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
-      await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
-    } else {
-      await utils.addIssueLabels(context, [APP_STORE_LABEL]);
-    }
+    await utils.addIssueLabels(context, [APP_STORE_LABEL]);
   }
 };

--- a/src/triageTemplate.ts
+++ b/src/triageTemplate.ts
@@ -8,6 +8,7 @@ import {
   PLATFORM_WIN,
   PLATFORM_LINUX,
   APP_STORE_LABEL,
+  MISSING_INFO_LABEL,
 } from './constants';
 
 const triageVersion = async (version: string, context: Context): Promise<Boolean> => {
@@ -61,7 +62,7 @@ const triagePlatform = async (platform: string, context: Context): Promise<Boole
         }),
       );
     } else {
-      await utils.addIssueLabels(labelsToAdd, context);
+      await utils.addIssueLabels(context, labelsToAdd);
     }
     return true;
   }
@@ -71,6 +72,7 @@ const triagePlatform = async (platform: string, context: Context): Promise<Boole
 export const triageBugReport = async (
   components: Record<string, { raw: string }>,
   context: Context,
+  update: Boolean,
 ) => {
   let missingInfo: string[] = [];
 
@@ -86,16 +88,21 @@ export const triageBugReport = async (
   const actualBehavior = components['Actual Behavior'].raw;
   if (actualBehavior === '') missingInfo.push('Actual Behavior');
 
-  if (missingInfo.length > 0) {
+  if (!update && missingInfo.length > 0) {
     await utils.notifyMissingInfo(context, missingInfo);
   } else {
-    await utils.addIssueLabels([BUG_LABEL], context);
+    if (update && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
+      await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
+    } else {
+      await utils.addIssueLabels(context, [BUG_LABEL]);
+    }
   }
 };
 
 export const triageFeatureRequest = async (
   components: Record<string, { raw: string }>,
   context: Context,
+  update: Boolean,
 ) => {
   let missingInfo: string[] = [];
 
@@ -108,16 +115,21 @@ export const triageFeatureRequest = async (
   const alternativeConsidered: string = components['Alternatives Considered'].raw;
   if (alternativeConsidered === '') missingInfo.push('Alternatives Considered');
 
-  if (missingInfo.length > 0) {
+  if (!update && missingInfo.length > 0) {
     await utils.notifyMissingInfo(context, missingInfo);
   } else {
-    await utils.addIssueLabels([ENHANCEMENT_LABEL], context);
+    if (update && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
+      await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
+    } else {
+      await utils.addIssueLabels(context, [ENHANCEMENT_LABEL]);
+    }
   }
 };
 
 export const triageMASRejection = async (
   components: Record<string, { raw: string }>,
   context: Context,
+  update: Boolean,
 ) => {
   let missingInfo: string[] = [];
 
@@ -127,9 +139,13 @@ export const triageMASRejection = async (
   const rejectionEmail: string = components['Rejection Email'].raw;
   if (rejectionEmail === '') missingInfo.push('Rejection Email');
 
-  if (missingInfo.length > 0) {
+  if (!update && missingInfo.length > 0) {
     await utils.notifyMissingInfo(context, missingInfo);
   } else {
-    await utils.addIssueLabels([APP_STORE_LABEL], context);
+    if (update && utils.labelExistsOnIssue(context, MISSING_INFO_LABEL)) {
+      await utils.removeIssueLabel(context, MISSING_INFO_LABEL);
+    } else {
+      await utils.addIssueLabels(context, [APP_STORE_LABEL]);
+    }
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,29 +36,50 @@ export const arrayContainsArray = (superset: string[], subset: string[]) => {
 export const notifyMissingInfo = async (context: Context, missingValues?: string[]) => {
   let body;
   if (missingValues) {
-    body = `Please fill out all applicable sections of the template
-    correctly for the maintainers to be able to triage your issue. 
-    You seem to be missing: ${missingValues.join(' ')}.`;
+    body = `Some items in the issue template appear to be missing. \
+Please provide \n${missingValues.map(val => `* **${val}**`).join('\n')}\n\n for \
+the maintainers to be able to triage your issue.`;
   } else {
-    body = `Please fill out all applicable sections of the template
-    correctly for the maintainers to be able to triage your issue.`;
+    body = `Please fill out all applicable sections of the template \
+correctly for the maintainers to be able to triage your issue.`;
   }
   await context.github.issues.createComment(context.issue({ body }));
   await context.github.issues.addLabels(
     context.repo({
-      number: context.payload.pull_request.number,
+      number: context.payload.issue.number,
       labels: [MISSING_INFO_LABEL],
     }),
   );
 };
 
-export const addIssueLabels = async (labelsToAdd: string[], context: Context) => {
+export const addIssueLabels = async (context: Context, labelsToAdd: string[]) => {
   await context.github.issues.addLabels(
     context.repo({
       number: context.payload.issue.number,
       labels: labelsToAdd,
     }),
   );
+};
+
+export const removeIssueLabel = async (context: Context, labelToRemove: string) => {
+  await context.github.issues.removeLabel(
+    context.repo({
+      number: context.payload.issue.number,
+      name: labelToRemove,
+    }),
+  );
+};
+
+export const labelExistsOnIssue = async (context: Context, labelName: string) => {
+  const labels = await context.github.issues.listLabelsOnIssue(
+    context.repo({
+      number: context.payload.issue.number,
+      per_page: 100,
+      page: 1,
+    }),
+  );
+
+  return labels.data.some(label => label.name === labelName);
 };
 
 export const createNoMatchComment = async (context: Context) => {


### PR DESCRIPTION
Adds logic to ensure that when issues are edited or reopened, the bot doesn't comment twice and just updates labels based on its previous actions. Also cleans up some miscellany and copyedits.

cc @MarshallOfSound