### PR TITLE
chore: don't apply new-pr label to spec prs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,5 +19,5 @@ export const PLATFORM_WIN = 'platform/windows';
 export const PLATFORM_LINUX = 'platform/linux';
 
 export const EXCLUDE_LABELS = [BACKPORT_LABEL, FAST_TRACK_LABEL];
-export const EXCLUDE_PREFIXES = ['build', 'ci'];
+export const EXCLUDE_PREFIXES = ['build', 'ci', 'spec'];
 export const EXCLUDE_USERS = ['roller-bot[bot]', 'electron-bot'];


### PR DESCRIPTION
Don't force a 24-hour hold on `spec`-only changes.

cc @MarshallOfSound @nornagon 