### PR TITLE
feat: handle api-review unlabeling

### DIFF
--- a/src/api-review-state.ts
+++ b/src/api-review-state.ts
@@ -1,28 +1,68 @@
 import { Application } from 'probot';
-import { ORGANIZATION, REPO, REVIEW_LABELS, SEMVER_LABELS } from './constants';
+import { API_REVIEW_CHECK_NAME, CheckRunStatus, REVIEW_LABELS, SEMVER_LABELS } from './constants';
+import { isAPIReviewRequired } from './utils/check-utils';
 
 export function setupAPIReviewStateManagement(probot: Application) {
   probot.on('pull_request.labeled', async context => {
-    const {
-      label,
-      pull_request: { number },
-    } = context.payload;
+    const { label, pull_request: pr } = context.payload;
 
     // If a PR is semver-minor or semver-major, automatically
     // add the 'api-review/requested 🗳' label.
     if ([SEMVER_LABELS.MINOR, SEMVER_LABELS.MAJOR].includes(label!.name)) {
       probot.log(
         'Received a semver-minor or semver-major PR:',
-        `${context.payload.repository.full_name}#${number}`,
+        `${context.payload.repository.full_name}#${pr.number}`,
         "Adding the 'api-review/requested 🗳' label",
       );
 
-      context.github.issues.addLabels({
-        owner: ORGANIZATION,
-        repo: REPO,
-        issue_number: number,
-        labels: [REVIEW_LABELS.REQUESTED],
-      });
+      context.github.issues.addLabels(
+        context.repo({
+          issue_number: pr.number,
+          labels: [REVIEW_LABELS.REQUESTED],
+        }),
+      );
+    }
+  });
+
+  probot.on('pull_request.unlabeled', async context => {
+    const { label, pull_request: pr } = context.payload;
+
+    if (!label) {
+      throw new Error('Something went wrong - label does not exist.');
+    }
+
+    // We want to prevent tampering with api-review/* labels other than
+    // request labels - the bot should control the full review lifecycle.
+    if (Object.keys(REVIEW_LABELS).includes(label.name)) {
+      const { data: allChecks } = await context.github.checks.listForRef(
+        context.repo({
+          ref: pr.head.sha,
+          per_page: 100,
+        }),
+      );
+
+      const checkRun = allChecks.check_runs.find(run => run.name === API_REVIEW_CHECK_NAME);
+
+      // The 'api-review/requested 🗳' label can be removed if it does not violate requirements.
+      if (checkRun && label.name === REVIEW_LABELS.REQUESTED && !isAPIReviewRequired(pr)) {
+        await context.github.checks.update(
+          context.repo({
+            name: API_REVIEW_CHECK_NAME,
+            status: 'queued',
+            check_run_id: checkRun.id,
+            conclusion: CheckRunStatus.NEUTRAL,
+            completed_at: new Date().toISOString(),
+          }),
+        );
+      } else {
+        // Put the label back. Bad human.
+        context.github.issues.addLabels(
+          context.repo({
+            issue_number: pr.number,
+            labels: [label.name],
+          }),
+        );
+      }
     }
   });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,9 +5,6 @@ export const MINIMUM_MINOR_OPEN_TIME = 1000 * 60 * 60 * 24 * 7;
 // 168 Hour Minimum Time
 export const MINIMUM_MAJOR_OPEN_TIME = 1000 * 60 * 60 * 24 * 7;
 
-export const ORGANIZATION = 'electron';
-export const REPO = 'electron';
-
 // backport type labels
 export const NEW_PR_LABEL = 'new-pr 🌱';
 export const BACKPORT_LABEL = 'backport';
@@ -26,6 +23,14 @@ export const REVIEW_LABELS = {
   APPROVED: 'api-review/approved ✅',
   DECLINED: 'api-review/declined ❌',
 };
+
+export enum CheckRunStatus {
+  NEUTRAL = 'neutral',
+  FAILURE = 'failure',
+  SUCCESS = 'success',
+}
+
+export const API_REVIEW_CHECK_NAME = 'API Review';
 
 // exclusion labels
 export const EXCLUDE_LABELS = [BACKPORT_LABEL, BACKPORT_SKIP_LABEL, FAST_TRACK_LABEL];

--- a/src/utils/check-utils.ts
+++ b/src/utils/check-utils.ts
@@ -1,0 +1,22 @@
+import { WebhookPayloadWithRepository } from 'probot';
+import { SEMVER_LABELS } from '../constants';
+
+/**
+ * Returns whether or not the 'api-review/requested 🗳' label
+ * can be removed from a given pull request without violating
+ * requirements.
+ *
+ * @param pr The pull request being checked for API Review requirements.
+ */
+export function isAPIReviewRequired(pr: WebhookPayloadWithRepository['pull_request']): boolean {
+  if (!pr) return false;
+
+  // If it's not a semver-patch PR it must be reviewed.
+  for (const label of pr.labels) {
+    if ([SEMVER_LABELS.MAJOR, SEMVER_LABELS.MINOR].includes(label.name)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
This PR creates a check when a new PR is opened for API review management. This will ultimately be handled like Archaeologist - the API Review check will always exist and be neutral if not needed. It also handles potential unlabeling actions:

We want to prevent tampering with `api-review/*` labels other than request labels - the bot should control the full review lifecycle. Therefore, if an `api-review/*` label is removed there is only one circumstance under which this should be allowed. The `api-review/requested` label is the only label that can be removed by humans, and only if the PR is `semver-patch`. If any other `api-review/*` label is removed, it must be put back.