### PR TITLE
feat: remove api-review/* labels added by humans

### DIFF
--- a/src/api-review-state.ts
+++ b/src/api-review-state.ts
@@ -1,14 +1,20 @@
 import { Application } from 'probot';
-import { API_REVIEW_CHECK_NAME, CheckRunStatus, REVIEW_LABELS, SEMVER_LABELS } from './constants';
+import { API_REVIEW_CHECK_NAME, REVIEW_LABELS, SEMVER_LABELS } from './constants';
+import { CheckRunStatus } from './enums';
 import { isAPIReviewRequired } from './utils/check-utils';
+import { getEnvVar } from './utils/env-util';
 
 export function setupAPIReviewStateManagement(probot: Application) {
   probot.on('pull_request.labeled', async context => {
     const { label, pull_request: pr } = context.payload;
 
+    if (!label) {
+      throw new Error('Something went wrong - label does not exist.');
+    }
+
     // If a PR is semver-minor or semver-major, automatically
     // add the 'api-review/requested 🗳' label.
-    if ([SEMVER_LABELS.MINOR, SEMVER_LABELS.MAJOR].includes(label!.name)) {
+    if ([SEMVER_LABELS.MINOR, SEMVER_LABELS.MAJOR].includes(label.name)) {
       probot.log(
         'Received a semver-minor or semver-major PR:',
         `${context.payload.repository.full_name}#${pr.number}`,
@@ -21,6 +27,20 @@ export function setupAPIReviewStateManagement(probot: Application) {
           labels: [REVIEW_LABELS.REQUESTED],
         }),
       );
+    } else if (Object.values(REVIEW_LABELS).includes(label.name)) {
+      const sender = context.payload.sender.login;
+
+      // Humans can only add the 'api-review/requested 🗳' manually.
+      if (sender !== getEnvVar('BOT_USER_NAME') && label.name !== REVIEW_LABELS.REQUESTED) {
+        probot.log(`${sender} tried to add ${label.name} - this is not permitted.`);
+        // Remove the label. Bad human.
+        context.github.issues.removeLabel(
+          context.repo({
+            issue_number: pr.number,
+            name: label.name,
+          }),
+        );
+      }
     }
   });
 
@@ -33,7 +53,7 @@ export function setupAPIReviewStateManagement(probot: Application) {
 
     // We want to prevent tampering with api-review/* labels other than
     // request labels - the bot should control the full review lifecycle.
-    if (Object.keys(REVIEW_LABELS).includes(label.name)) {
+    if (Object.values(REVIEW_LABELS).includes(label.name)) {
       const { data: allChecks } = await context.github.checks.listForRef(
         context.repo({
           ref: pr.head.sha,
@@ -55,6 +75,9 @@ export function setupAPIReviewStateManagement(probot: Application) {
           }),
         );
       } else {
+        const sender = context.payload.sender.login;
+        probot.log(`${sender} tried to remove ${label.name} - this is not permitted.`);
+
         // Put the label back. Bad human.
         context.github.issues.addLabels(
           context.repo({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,12 +24,6 @@ export const REVIEW_LABELS = {
   DECLINED: 'api-review/declined ❌',
 };
 
-export enum CheckRunStatus {
-  NEUTRAL = 'neutral',
-  FAILURE = 'failure',
-  SUCCESS = 'success',
-}
-
 export const API_REVIEW_CHECK_NAME = 'API Review';
 
 // exclusion labels

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,12 @@
+export enum CheckRunStatus {
+  NEUTRAL = 'neutral',
+  FAILURE = 'failure',
+  SUCCESS = 'success',
+}
+
+export enum LogLevel {
+  LOG,
+  INFO,
+  WARN,
+  ERROR,
+}

--- a/src/utils/env-util.ts
+++ b/src/utils/env-util.ts
@@ -1,0 +1,21 @@
+import { LogLevel } from '../enums';
+import { log } from './log-util';
+
+/**
+ * Checks that a given environment variable exists, and returns
+ * its value if it does. Conditionally throws an error on failure.
+ *
+ * @param {string} envVar - the environment variable to retrieve
+ * @param {string} defaultValue - default value to use if no environment var is found
+ * @returns {string} - the value of the env var being checked, or the default value if one is passed
+ */
+export function getEnvVar(envVar: string, defaultValue?: string): string {
+  log('getEnvVar', LogLevel.INFO, `Fetching env var '${envVar}'`);
+
+  const value = process.env[envVar] || defaultValue;
+  if (!value && value !== '') {
+    log('getEnvVar', LogLevel.ERROR, `Missing environment variable '${envVar}'`);
+    throw new Error(`Missing environment variable '${envVar}'`);
+  }
+  return value;
+}

--- a/src/utils/log-util.ts
+++ b/src/utils/log-util.ts
@@ -1,0 +1,22 @@
+import { LogLevel } from '../enums';
+
+/**
+ * Logs information about different actions taking place to console.
+ *
+ * @param {string} functionName - the name of the function where the logging is happening
+ * @param {LogLevel }logLevel - the severity level of the log
+ * @param {any[]} message - the message to write to console
+ */
+export const log = (functionName: string, logLevel: LogLevel, ...message: any[]) => {
+  const output = `${functionName}: ${message}`;
+
+  if (logLevel === LogLevel.INFO) {
+    console.info(output);
+  } else if (logLevel === LogLevel.WARN) {
+    console.warn(output);
+  } else if (logLevel === LogLevel.ERROR) {
+    console.error(output);
+  } else {
+    console.log(output);
+  }
+};


### PR DESCRIPTION
Humans can only add the 'api-review/requested 🗳' manually. If other `api-review/*` labels are added, remove them.