### PR TITLE
feat: allow semver/none in the semver label enforcement check

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,8 @@ export const NEW_PR_LABEL = 'new-pr 🌱';
 export const BACKPORT_LABEL = 'backport';
 export const BACKPORT_SKIP_LABEL = 'backport-check-skip';
 export const FAST_TRACK_LABEL = 'fast-track 🚅';
+
+export const SEMVER_NONE_LABEL = 'semver/none';
 export const SEMVER_LABELS = {
   PATCH: 'semver/patch',
   MINOR: 'semver/minor',

--- a/src/enforce-semver-labels.ts
+++ b/src/enforce-semver-labels.ts
@@ -1,7 +1,12 @@
 import { Probot } from 'probot';
-import { SEMVER_LABELS } from './constants';
+import { SEMVER_LABELS, SEMVER_NONE_LABEL } from './constants';
 
-const ALL_SEMVER_LABELS = [SEMVER_LABELS.MAJOR, SEMVER_LABELS.MINOR, SEMVER_LABELS.PATCH];
+const ALL_SEMVER_LABELS = [
+  SEMVER_LABELS.MAJOR,
+  SEMVER_LABELS.MINOR,
+  SEMVER_LABELS.PATCH,
+  SEMVER_NONE_LABEL,
+];
 
 export function setupSemverLabelEnforcement(probot: Probot) {
   probot.on(


### PR DESCRIPTION
Added explicitly here instead of to the enum as other things probably shouldn't be using it, it's an exception case