### PR TITLE
chore: update deprecated WebhookError props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,13 @@ import { setupSemverLabelEnforcement } from './enforce-semver-labels';
 import { setupAPIReviewStateManagement } from './api-review-state';
 
 const probotHandler = async ({ app }: { app: Probot }) => {
-  app.on('error', event => {
-    for (const error of event.errors) {
+  app.on('error', errorEvent => {
+    for (const error of Array.from(errorEvent)) {
       if (process.env.SENTRY_DSN) {
         Sentry.captureException(error, {
           req: error.request,
           extra: {
-            event: error.event,
+            event: errorEvent.event,
             status: error.status,
           },
         } as any);


### PR DESCRIPTION
Addresses:

<img width="581" alt="Screen Shot 2020-12-10 at 12 55 54 PM" src="https://user-images.githubusercontent.com/2036040/101828919-1048e080-3ae7-11eb-9dbf-4d23cd8b7d87.png">

<img width="601" alt="Screen Shot 2020-12-10 at 12 55 48 PM" src="https://user-images.githubusercontent.com/2036040/101828925-1343d100-3ae7-11eb-87e5-c0324ddac58f.png">
