### PR TITLE
fix: don't remove nonexistent labels

### DIFF
--- a/src/24-hour-rule.ts
+++ b/src/24-hour-rule.ts
@@ -13,6 +13,7 @@ import {
 import { EventPayloads } from '@octokit/webhooks';
 import { addOrUpdateAPIReviewCheck } from './api-review-state';
 import { log } from './utils/log-util';
+import { removeLabel } from './utils/label-utils';
 import { LogLevel } from './enums';
 
 const CHECK_INTERVAL = 1000 * 60 * 5;
@@ -85,12 +86,13 @@ export const applyLabelToPR = async (
     );
 
     try {
-      await github.issues.removeLabel({
+      await removeLabel(github, {
         owner: repoOwner,
         repo: repoName,
-        issue_number: pr.number,
+        prNumber: pr.number,
         name: NEW_PR_LABEL,
       });
+
       pr.labels = pr.labels.filter(l => l.name !== NEW_PR_LABEL);
       await addOrUpdateAPIReviewCheck(github, pr);
     } catch {

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -1,0 +1,47 @@
+import { Context } from 'probot';
+import { log } from './log-util';
+import { LogLevel } from '../enums';
+
+export const removeLabel = async (
+  octokit: Context['octokit'],
+  data: {
+    prNumber: number;
+    owner: string;
+    repo: string;
+    name: string;
+  },
+) => {
+  log('removeLabel', LogLevel.INFO, `Removing ${data.name} from PR #${data.prNumber}`);
+
+  // If the issue does not have the label, don't try remove it
+  if (!(await labelExistsOnPR(octokit, data))) return;
+
+  return octokit.issues.removeLabel({
+    owner: data.owner,
+    repo: data.repo,
+    issue_number: data.prNumber,
+    name: data.name,
+  });
+};
+
+export const labelExistsOnPR = async (
+  octokit: Context['octokit'],
+  data: {
+    prNumber: number;
+    owner: string;
+    repo: string;
+    name: string;
+  },
+) => {
+  log('labelExistsOnPR', LogLevel.INFO, `Checking if ${data.name} exists on #${data.prNumber}`);
+
+  const labels = await octokit.issues.listLabelsOnIssue({
+    owner: data.owner,
+    repo: data.repo,
+    issue_number: data.prNumber,
+    per_page: 100,
+    page: 1,
+  });
+
+  return labels.data.some(label => label.name === data.name);
+};


### PR DESCRIPTION
Fixes 404s seen in Sentry:

<img width="793" alt="Screen Shot 2020-12-10 at 1 41 19 PM" src="https://user-images.githubusercontent.com/2036040/101835386-9158a580-3af0-11eb-8322-0b476873d636.png">

caused by trying to remove labels which don't exist on a a given PR.