### PR TITLE
fix: update title when Check is reset

### DIFF
--- a/src/api-review-state.ts
+++ b/src/api-review-state.ts
@@ -57,6 +57,7 @@ export async function addOrUpdateAPIReviewCheck(
       repo: pr.head.repo.name,
       name: API_REVIEW_CHECK_NAME,
       status: 'completed',
+      title: 'PR no longer requires API Review',
       check_run_id: checkRun.id,
       conclusion: CheckRunStatus.NEUTRAL,
     });


### PR DESCRIPTION
What it says on the tin. Make it clearer when the `api-review-required` label is removed from a PR what that means for the check.