### PR TITLE
fix: update API Review labels when new-pr is gone

### DIFF
--- a/src/24-hour-rule.ts
+++ b/src/24-hour-rule.ts
@@ -179,16 +179,9 @@ export function setUp24HourRule(probot: Probot) {
 
       for (const pr of prs) {
         const shouldLabel = shouldPRHaveLabel(pr as any);
-        const labelExists = await labelExistsOnPR(octokit, {
-          owner: repo.owner.login,
-          repo: repo.name,
-          prNumber: pr.number,
-          name: NEW_PR_LABEL,
-        });
 
-        // We also need to ensure that API review labels are updated when the requisite
-        // waiting period expires.
-        if (labelExists && !shouldLabel) {
+        // Ensure that API review labels are updated after waiting period.
+        if (!shouldLabel) {
           const approvalState = await addOrUpdateAPIReviewCheck(octokit, pr as any, {});
           await checkPRReadyForMerge(octokit, pr as any, approvalState);
         }


### PR DESCRIPTION
Close https://github.com/electron/cation/issues/74.

Fixes an issue where the API Review labels check wouldn't be updated after the `new-pr 🌱` label was removed.

cc @jkleinsc 