### PR TITLE
feat: take ready-for-review into account for open time

### DIFF
--- a/spec/fixtures/pr-open-time/pull_request.opened.json
+++ b/spec/fixtures/pr-open-time/pull_request.opened.json
@@ -51,6 +51,11 @@
         "description": "backwards-incompatible bug fixes"
       }
     ],
+    "base": {
+      "repo": {
+        "full_name": "electron/electron"
+      }
+    },
     "milestone": null,
     "draft": false,
     "commits_url": "https://api.github.com/repos/electron/electron/pulls/26876/commits",

--- a/spec/fixtures/pr-open-time/pull_request.semver-major.json
+++ b/spec/fixtures/pr-open-time/pull_request.semver-major.json
@@ -48,6 +48,11 @@
       "description": "backwards-incompatible bug fixes"
     }
   ],
+  "base": {
+    "repo": {
+      "full_name": "electron/electron"
+    }
+  },
   "milestone": null,
   "draft": false,
   "commits_url": "https://api.github.com/repos/electron/electron/pulls/26876/commits",

--- a/spec/fixtures/pr-open-time/pull_request.semver-minor.json
+++ b/spec/fixtures/pr-open-time/pull_request.semver-minor.json
@@ -48,6 +48,11 @@
       "description": "new features"
     }
   ],
+  "base": {
+    "repo": {
+      "full_name": "electron/electron"
+    }
+  },
   "milestone": null,
   "draft": false,
   "commits_url": "https://api.github.com/repos/electron/electron/pulls/26876/commits",

--- a/spec/fixtures/pr-open-time/pull_request.semver-missing.json
+++ b/spec/fixtures/pr-open-time/pull_request.semver-missing.json
@@ -30,6 +30,11 @@
     "type": "User",
     "site_admin": false
   },
+  "base": {
+    "repo": {
+      "full_name": "electron/electron"
+    }
+  },
   "body": "* Ensure --fix output is actually written to disk\r\n* Cache bust on lint.js file changes\r\n* Ensure CI does not use the linting cache\r\n\r\nNotes: no-notes",
   "created_at": "2020-12-08T01:24:55Z",
   "updated_at": "2020-12-08T01:24:55Z",

--- a/spec/fixtures/pr-open-time/pull_request.semver-none.json
+++ b/spec/fixtures/pr-open-time/pull_request.semver-none.json
@@ -48,6 +48,11 @@
       "description": "new features"
     }
   ],
+  "base": {
+    "repo": {
+      "full_name": "electron/electron"
+    }
+  },
   "milestone": null,
   "draft": false,
   "commits_url": "https://api.github.com/repos/electron/electron/pulls/26876/commits",

--- a/spec/fixtures/pr-open-time/pull_request.semver-patch.json
+++ b/spec/fixtures/pr-open-time/pull_request.semver-patch.json
@@ -48,6 +48,11 @@
       "description": "backwards-compatible bug fixes"
     }
   ],
+  "base": {
+    "repo": {
+      "full_name": "electron/electron"
+    }
+  },
   "milestone": null,
   "draft": false,
   "commits_url": "https://api.github.com/repos/electron/electron/pulls/26876/commits",

--- a/spec/fixtures/pr-open-time/pull_request.should_label.json
+++ b/spec/fixtures/pr-open-time/pull_request.should_label.json
@@ -48,6 +48,11 @@
       "description": "new features"
     }
   ],
+  "base": {
+    "repo": {
+      "full_name": "electron/electron"
+    }
+  },
   "milestone": null,
   "draft": false,
   "commits_url": "https://api.github.com/repos/electron/electron/pulls/26876/commits",

--- a/spec/fixtures/pr-open-time/pull_request.should_not_label.json
+++ b/spec/fixtures/pr-open-time/pull_request.should_not_label.json
@@ -30,6 +30,11 @@
     "type": "User",
     "site_admin": false
   },
+  "base": {
+    "repo": {
+      "full_name": "electron/electron"
+    }
+  },
   "body": "* Ensure --fix output is actually written to disk\r\n* Cache bust on lint.js file changes\r\n* Ensure CI does not use the linting cache\r\n\r\nNotes: no-notes",
   "created_at": "2020-12-08T01:24:55Z",
   "updated_at": "2020-12-08T01:24:55Z",

--- a/src/24-hour-rule.ts
+++ b/src/24-hour-rule.ts
@@ -14,11 +14,18 @@ import {
 import { EventPayloads } from '@octokit/webhooks';
 import { addOrUpdateAPIReviewCheck, checkPRReadyForMerge } from './api-review-state';
 import { log } from './utils/log-util';
-import { addLabels, labelExistsOnPR, removeLabel } from './utils/label-utils';
+import { addLabels, removeLabel } from './utils/label-utils';
+import { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
 import { LogLevel } from './enums';
 
 const CHECK_INTERVAL = 1000 * 60 * 5;
 
+/**
+ *
+ * @param {EventPayloads.WebhookPayloadPullRequestPullRequest} pr
+ * @returns {number} a number representing the minimum open time for the PR
+ * based on  its semantic prefix in milliseconds
+ */
 export const getMinimumOpenTime = (
   pr: EventPayloads.WebhookPayloadPullRequestPullRequest,
 ): number => {
@@ -34,9 +41,45 @@ export const getMinimumOpenTime = (
   return MINIMUM_MAJOR_OPEN_TIME;
 };
 
-export const shouldPRHaveLabel = (
+/**
+ *
+ * @param {Context['github']}  github An Octokit instance
+ * @param {EventPayloads.WebhookPayloadPullRequestPullRequest} pr
+ * @returns {number} a number representing the that cation should use as the
+ * open time for the PR in milliseconds, taking draft status into account.
+ */
+export const getPROpenedTime = async (
+  github: Context['octokit'],
   pr: EventPayloads.WebhookPayloadPullRequestPullRequest,
-): boolean => {
+): Promise<number> => {
+  const [owner, repo] = pr.base.repo.full_name.split('/');
+
+  // Fetch PR timeline events.
+  const { data: events } = (await github.issues.listEventsForTimeline({
+    owner,
+    repo,
+    issue_number: pr.number,
+  })) as RestEndpointMethodTypes['issues']['listEventsForTimeline']['response'];
+
+  // Filter out all except 'Ready For Review' events.
+  const readyForReviewEvents = events
+    .sort(({ created_at: cA }, { created_at: cB }) => {
+      return new Date(cB).getTime() - new Date(cA).getTime();
+    })
+    .filter(e => e.event === 'ready_for_review');
+
+  // If this PR was a draft PR previously, set its opened time as a function
+  // of when it was most recently marked ready for review instead of when it was opened,
+  // otherwise return the PR open date.
+  return readyForReviewEvents.length > 0
+    ? new Date(readyForReviewEvents[0].created_at).getTime()
+    : new Date(pr.created_at).getTime();
+};
+
+export const shouldPRHaveLabel = async (
+  github: Context['octokit'],
+  pr: EventPayloads.WebhookPayloadPullRequestPullRequest,
+): Promise<boolean> => {
   log('shouldPRHaveLabel', LogLevel.INFO, `Checking whether #${pr.number} should have label.`);
 
   const prefix = pr.title.split(':')[0];
@@ -52,7 +95,7 @@ export const shouldPRHaveLabel = (
   )
     return false;
 
-  const created = new Date(pr.created_at).getTime();
+  const created = await getPROpenedTime(github, pr);
   const now = Date.now();
 
   return now - created < getMinimumOpenTime(pr);
@@ -61,34 +104,34 @@ export const shouldPRHaveLabel = (
 export const applyLabelToPR = async (
   github: Context['octokit'],
   pr: EventPayloads.WebhookPayloadPullRequestPullRequest,
-  repoOwner: string,
-  repoName: string,
   shouldHaveLabel: boolean,
 ) => {
+  const [owner, repo] = pr.base.repo.full_name.split('/');
+
   if (shouldHaveLabel) {
     log(
       'applyLabelToPR',
       LogLevel.INFO,
-      `Found PR ${repoOwner}/${repoName}#${pr.number} - should ensure ${NEW_PR_LABEL} label exists.`,
+      `Found PR ${owner}/${repo}#${pr.number} - should ensure ${NEW_PR_LABEL} label exists.`,
     );
 
     await addLabels(github, {
       prNumber: pr.number,
       labels: [NEW_PR_LABEL],
-      repo: repoName,
-      owner: repoOwner,
+      repo,
+      owner,
     });
   } else {
     log(
       'applyLabelToPR',
       LogLevel.INFO,
-      `Found PR ${repoOwner}/${repoName}#${pr.number} - should ensure ${NEW_PR_LABEL} label does not exist.`,
+      `Found PR ${owner}/${repo}#${pr.number} - should ensure ${NEW_PR_LABEL} label does not exist.`,
     );
 
     try {
       await removeLabel(github, {
-        owner: repoOwner,
-        repo: repoName,
+        owner,
+        repo,
         prNumber: pr.number,
         name: NEW_PR_LABEL,
       });
@@ -116,6 +159,7 @@ export function setUp24HourRule(probot: Probot) {
   probot.on(
     ['pull_request.opened', 'pull_request.unlabeled', 'pull_request.labeled'],
     async context => {
+      probot.log('context.octokit', context.octokit);
       const { action, label, pull_request: pr, repository } = context.payload;
 
       // We only care about user labels adds for new-pr and semver labels.
@@ -123,13 +167,9 @@ export function setUp24HourRule(probot: Probot) {
 
       probot.log(`24-hour rule received PR: ${repository.full_name}#${pr.number} checking now`);
 
-      await applyLabelToPR(
-        context.octokit,
-        pr,
-        context.repo({}).owner,
-        context.repo({}).repo,
-        shouldPRHaveLabel(pr),
-      );
+      const shouldLabel = await shouldPRHaveLabel(context.octokit, pr);
+
+      await applyLabelToPR(context.octokit, pr, shouldLabel);
     },
   );
 
@@ -178,7 +218,7 @@ export function setUp24HourRule(probot: Probot) {
       probot.log(`Found ${prs.length} prs for repo: ${repo.owner.login}/${repo.name}`);
 
       for (const pr of prs) {
-        const shouldLabel = shouldPRHaveLabel(pr as any);
+        const shouldLabel = await shouldPRHaveLabel(octokit, pr as any);
 
         // Ensure that API review labels are updated after waiting period.
         if (!shouldLabel) {
@@ -186,7 +226,7 @@ export function setUp24HourRule(probot: Probot) {
           await checkPRReadyForMerge(octokit, pr as any, approvalState);
         }
 
-        await applyLabelToPR(octokit, pr as any, repo.owner.login, repo.name, shouldLabel);
+        await applyLabelToPR(octokit, pr as any, shouldLabel);
       }
     }
   }

--- a/src/24-hour-rule.ts
+++ b/src/24-hour-rule.ts
@@ -63,10 +63,10 @@ export const getPROpenedTime = async (
 
   // Filter out all except 'Ready For Review' events.
   const readyForReviewEvents = events
+    .filter(e => e.event === 'ready_for_review')
     .sort(({ created_at: cA }, { created_at: cB }) => {
       return new Date(cB).getTime() - new Date(cA).getTime();
-    })
-    .filter(e => e.event === 'ready_for_review');
+    });
 
   // If this PR was a draft PR previously, set its opened time as a function
   // of when it was most recently marked ready for review instead of when it was opened,
@@ -159,7 +159,6 @@ export function setUp24HourRule(probot: Probot) {
   probot.on(
     ['pull_request.opened', 'pull_request.unlabeled', 'pull_request.labeled'],
     async context => {
-      probot.log('context.octokit', context.octokit);
       const { action, label, pull_request: pr, repository } = context.payload;
 
       // We only care about user labels adds for new-pr and semver labels.


### PR DESCRIPTION
Closes https://github.com/electron/cation/issues/13.

Applies PR label based _either_ on date when PR was opened, if it was never a draft, or the date that the PR was most recently marked ready for review.