### PR TITLE
fix: use existing `documentation 📓` label

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const BACKPORT_LABEL = 'backport';
 export const BACKPORT_SKIP_LABEL = 'backport-check-skip';
 export const FAST_TRACK_LABEL = 'fast-track 🚅';
 
-export const DOCUMENTATION_LABEL = 'documentation 📓';
+export const DOCUMENTATION_LABEL = 'documentation :notebook:';
 
 export const SEMVER_PREFIX = 'semver/';
 export const SEMVER_NONE_LABEL = 'semver/none';


### PR DESCRIPTION
👋 Hey Cation enthusiasts,

There seems to be a small papercut with the docs labeling in #92. Seems like the existing label we've been using forever is [`documentation :notebook:`](https://github.com/electron/electron/pulls?q=is%3Apr+is%3Aopen+label%3A%22documentation+%3Anotebook%3A%22) rather than [`documentation 📓`](https://github.com/electron/electron/labels/documentation%20%F0%9F%93%93).

I think we should be going with the old label for consistency. We can also close this PR and do some label configuration (renaming the old label to directly use the emoji), but I don't have enough perms on the GitHub org to do that.