### PR TITLE
chore: add trop to excluded users

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,4 +53,4 @@ export const API_WORKING_GROUP = 'wg-api';
 // exclusion labels
 export const EXCLUDE_LABELS = [BACKPORT_LABEL, BACKPORT_SKIP_LABEL, FAST_TRACK_LABEL];
 export const EXCLUDE_PREFIXES = ['build', 'ci', 'test'];
-export const EXCLUDE_USERS = ['roller-bot[bot]', 'electron-bot'];
+export const EXCLUDE_USERS = ['roller-bot[bot]', 'electron-bot', 'trop[bot]'];


### PR DESCRIPTION
I'm not super familiar with `cation`, but on face value this feels correct? Labeling `trop` created PRs seems unnecessary and causes [stuff like this](https://github.com/electron/electron/pull/33147) where you get labels which don't provide any benefit on a backport (documentation), and conflicting labels (`semver/none` vs `semver/patch`).