### PR TITLE
fix: only add labels to default branch

### DIFF
--- a/spec/fixtures/add-triage-labels/build_pr_opened.json
+++ b/spec/fixtures/add-triage-labels/build_pr_opened.json
@@ -15,7 +15,13 @@
     "updated_at": "2020-12-08T01:24:55Z",
     "closed_at": null,
     "merged_at": null,
-    "labels": []
+    "labels": [],
+    "base": {
+      "ref": "main",
+      "repo": {
+        "default_branch": "main"
+      }
+    }
   },
   "repository": {
     "id": 9384267,

--- a/spec/fixtures/add-triage-labels/ci_pr_opened.json
+++ b/spec/fixtures/add-triage-labels/ci_pr_opened.json
@@ -15,7 +15,13 @@
     "updated_at": "2020-12-08T01:24:55Z",
     "closed_at": null,
     "merged_at": null,
-    "labels": []
+    "labels": [],
+    "base": {
+      "ref": "main",
+      "repo": {
+        "default_branch": "main"
+      }
+    }
   },
   "repository": {
     "id": 9384267,

--- a/spec/fixtures/add-triage-labels/docs_pr_opened.json
+++ b/spec/fixtures/add-triage-labels/docs_pr_opened.json
@@ -15,7 +15,13 @@
     "updated_at": "2020-12-08T01:24:55Z",
     "closed_at": null,
     "merged_at": null,
-    "labels": []
+    "labels": [],
+    "base": {
+      "ref": "main",
+      "repo": {
+        "default_branch": "main"
+      }
+    }
   },
   "repository": {
     "id": 9384267,

--- a/spec/fixtures/add-triage-labels/test_pr_opened.json
+++ b/spec/fixtures/add-triage-labels/test_pr_opened.json
@@ -15,7 +15,13 @@
     "updated_at": "2020-12-08T01:24:55Z",
     "closed_at": null,
     "merged_at": null,
-    "labels": []
+    "labels": [],
+    "base": {
+      "ref": "main",
+      "repo": {
+        "default_branch": "main"
+      }
+    }
   },
   "repository": {
     "id": 9384267,

--- a/src/add-triage-labels.ts
+++ b/src/add-triage-labels.ts
@@ -12,6 +12,9 @@ export function addBasicPRLabels(probot: Probot) {
   probot.on(['pull_request.opened', 'pull_request.edited'], async context => {
     const { pull_request: pr } = context.payload;
 
+    // Only add triage labels to the default branch.
+    if (pr.base.ref !== pr.base.repo.default_branch) return;
+
     const hasSemverLabel = pr.labels.some((l: any) => {
       l.name.startsWith(SEMVER_PREFIX);
     });


### PR DESCRIPTION
Only apply triage labels to PRs targeting master.

Trop handles backport labeling.