### PR TITLE
fix: removing LGTM comments with reviews

### DIFF
--- a/src/api-review-state.ts
+++ b/src/api-review-state.ts
@@ -102,8 +102,11 @@ export async function addOrUpdateAPIReviewCheck(
       repo,
       pull_number: pr.number,
     })
-  ).data.filter(({ user }) => members.includes(user.login));
+  ).data.filter(({ user, body }) => {
+    return members.includes(user.login) && body.length !== 0;
+  });
 
+  // Filter comments by those from members of the API Working Group.
   const comments = (
     await octokit.issues.listComments({
       owner,


### PR DESCRIPTION
Fixes issue seen in https://github.com/electron/electron/pull/35438 and https://github.com/electron/electron/pull/34526, where reviewers who left API LGTM comments would not have those comments recognized as formal approvals.

We were incorrectly making the implicit assumption that people who were commenting were _not_ also reviewing. - the logic deduplicates but also potentially filtered out LGTM comments from people who had _also_ left a review with no comment body.

This fixes that by initially filtering out all reviews with no comment body.