### PR TITLE
fix: don't apply new-pr to merged PRs

### DIFF
--- a/spec/24-hour-rule.spec.ts
+++ b/spec/24-hour-rule.spec.ts
@@ -99,6 +99,14 @@ describe('pr open time', () => {
     expect(noLabel).toEqual(false);
   });
 
+  it('does not add the new-pr label to merged PRs', async () => {
+    const payload = require('./fixtures/pr-open-time/pull_request.should_label.json');
+    payload.merged = true;
+
+    const label = await shouldPRHaveLabel(moctokit, payload);
+    expect(label).toEqual(false);
+  });
+
   it('correctly determines whether a label if relevant to the decision tree', () => {
     expect(
       labelShouldBeChecked({

--- a/src/24-hour-rule.ts
+++ b/src/24-hour-rule.ts
@@ -91,7 +91,8 @@ export const shouldPRHaveLabel = async (
     EXCLUDE_PREFIXES.includes(prefix) ||
     hasExcludedLabel ||
     backportInTitle ||
-    EXCLUDE_USERS.includes(pr.user.login)
+    EXCLUDE_USERS.includes(pr.user.login) ||
+    pr.merged
   )
     return false;
 


### PR DESCRIPTION
Closes https://github.com/electron/cation/issues/128.