### PR TITLE
chore: add semver/major checklist item to deprecation review

### DIFF
--- a/assets/deprecation-checklist.md
+++ b/assets/deprecation-checklist.md
@@ -2,7 +2,6 @@
 
 ### 🔥 New deprecations in this PR
 
-- [ ] 🏷️ Pull request is labeled as https://github.com/electron/electron/labels/semver%2Fmajor
 - [ ] 📢 Are called out in [`docs/breaking-changes.md`][]
 - [ ] ⚠️ Use the deprecation helpers in [`lib/common/deprecate.ts`](https://github.com/electron/electron/blob/main/lib/common/deprecate.ts) to warn about usage (including events)
 - [ ] 📝 Are marked as deprecated in the docs, using `_Deprecated_` (including properties and events)

--- a/assets/deprecation-checklist.md
+++ b/assets/deprecation-checklist.md
@@ -2,6 +2,7 @@
 
 ### 🔥 New deprecations in this PR
 
+- [ ] 🏷️ Pull request is labeled as https://github.com/electron/electron/labels/semver%2Fmajor
 - [ ] 📢 Are called out in [`docs/breaking-changes.md`][]
 - [ ] ⚠️ Use the deprecation helpers in [`lib/common/deprecate.ts`](https://github.com/electron/electron/blob/main/lib/common/deprecate.ts) to warn about usage (including events)
 - [ ] 📝 Are marked as deprecated in the docs, using `_Deprecated_` (including properties and events)
@@ -9,6 +10,7 @@
 
 ### 🗑️ Previous deprecations being removed in this PR
 
+- [ ] 🏷️ Pull request is labeled as https://github.com/electron/electron/labels/semver%2Fmajor
 - [ ] 📢 Are called out as removed in [`docs/breaking-changes.md`][]
 - [ ] 📝 Are fully removed from the docs
 - [ ] ⌨️ All relevant code is removed


### PR DESCRIPTION
I incorrectly labeled https://github.com/electron/electron/pull/39341 as `semver/minor` - let's add a checklist item to ensure any deprecation PRs with removals are labeled as major. The link will render nicely as a label over on `e/e`.