### PR TITLE
fix: only comment on event for deprecation-review/requested label added

### DIFF
--- a/src/deprecation-review-state.ts
+++ b/src/deprecation-review-state.ts
@@ -173,7 +173,6 @@ export function setupDeprecationReviewStateManagement(probot: Probot) {
   probot.on(
     ['pull_request.synchronize', 'pull_request.opened'],
     async (context: Context<'pull_request'>) => {
-      await maybeAddChecklistComment(context.octokit, context.payload.pull_request);
       await addOrUpdateDeprecationReviewCheck(context.octokit, context.payload.pull_request);
     },
   );
@@ -208,9 +207,12 @@ export function setupDeprecationReviewStateManagement(probot: Probot) {
           name: label.name,
         });
       }
+
+      if (label.name === DEPRECATION_REVIEW_LABELS.REQUESTED) {
+        await maybeAddChecklistComment(context.octokit, context.payload.pull_request);
+      }
     }
 
-    await maybeAddChecklistComment(context.octokit, context.payload.pull_request);
     await addOrUpdateDeprecationReviewCheck(context.octokit, pr);
   });
 


### PR DESCRIPTION
Fixes a race condition which happened on https://github.com/electron/electron/pull/39696 when the label was added at the same time as the PR was created. While there is a check to see if the comment already exists, since each webhook for label added was being processed in parallel, they all added the comment. Only add the comment if the relevant label is what triggered the event.