### PR TITLE
feat: replace PR "Request Changes" with a "API CHANGES REQUESTED" comment

### DIFF
--- a/spec/api-review-state.spec.ts
+++ b/spec/api-review-state.spec.ts
@@ -170,7 +170,7 @@ describe('api review', () => {
       data: [
         {
           user: { id: 1, login: 'ckerr' },
-          body: 'Fix this please!',
+          body: 'API CHANGES REQUESTED',
           state: 'CHANGES_REQUESTED',
         },
         {
@@ -188,6 +188,11 @@ describe('api review', () => {
           body: 'API DECLINED',
           state: 'COMMENTED',
         },
+        {
+          user: { id: 5, login: 'itsananderson' },
+          body: 'API CHANGES REQUESTED',
+          state: 'COMMENTED',
+        },
       ],
     });
 
@@ -197,6 +202,7 @@ describe('api review', () => {
         { login: 'jkleinsc' },
         { login: 'nornagon' },
         { login: 'ckerr' },
+        { login: 'itsananderson' },
       ],
     });
 
@@ -212,6 +218,7 @@ describe('api review', () => {
 #### Requested Changes
 
 * @ckerr
+* @itsananderson
 #### Declined
 
 * @jkleinsc
@@ -226,7 +233,7 @@ describe('api review', () => {
     expect(users).toEqual({
       approved: ['codebytere', 'nornagon'],
       declined: ['jkleinsc'],
-      requestedChanges: ['ckerr'],
+      requestedChanges: ['ckerr', 'itsananderson'],
     });
   });
 
@@ -250,8 +257,8 @@ describe('api review', () => {
         },
         {
           user: { id: 2, login: 'jkleinsc' },
-          body: 'This test is failing!!',
-          state: 'CHANGES_REQUESTED',
+          body: 'API CHANGES REQUESTED',
+          state: 'COMMENTED',
           submitted_at: '2020-12-10T01:24:55Z',
         },
       ],
@@ -266,6 +273,40 @@ describe('api review', () => {
       approved: ['nornagon'],
       declined: [],
       requestedChanges: ['jkleinsc'],
+    });
+  });
+
+  it('should correctly parse user approvals when a reviewer requests changes and then approves', async () => {
+    const { pull_request } = loadFixture(
+      'api-review-state/pull_request.requested_review_label.json',
+    );
+
+    moctokit.pulls.listReviews.mockReturnValue({
+      data: [
+        {
+          user: { id: 2, login: 'marshallofsound' },
+          body: 'API CHANGES REQUESTED',
+          state: 'COMMENTED',
+          submitted_at: '2020-12-09T01:24:55Z',
+        },
+        {
+          user: { id: 2, login: 'marshallofsound' },
+          body: 'API LGTM',
+          state: 'COMMENTED',
+          submitted_at: '2020-12-10T01:24:55Z',
+        },
+      ],
+    });
+
+    moctokit.teams.listMembersInOrg.mockReturnValue({
+      data: [{ login: 'marshallofsound' }],
+    });
+
+    const users = await addOrUpdateAPIReviewCheck(moctokit, pull_request);
+    expect(users).toEqual({
+      approved: ['marshallofsound'],
+      declined: [],
+      requestedChanges: [],
     });
   });
 

--- a/src/api-review-state.ts
+++ b/src/api-review-state.ts
@@ -280,7 +280,7 @@ export async function addOrUpdateAPIReviewCheck(octokit: Context['octokit'], pr:
       output: {
         title: `${checkTitles[currentReviewLabel.name]} (${
           users.approved.length
-        }/2 Approvals/LGTMs - ready on ${getPRReadyDate(pr)})`,
+        }/2 LGTMs - ready on ${getPRReadyDate(pr)})`,
         summary: checkSummary,
       },
     });


### PR DESCRIPTION
This PR: https://github.com/electron/electron/pull/42561 illustrates an odd edge case in our approve/request changes workflow. If you request changes on the PR, the API Review is blocked (even if you were requesting changes to implementation or other non-API parts of the PR). If you subsequently approve the PR, the API Review is still blocked because we don't consider PR approvals to be API approvals.

After some discussion within the API WG, the consensus is that submitting a "Request Changes" to a PR should not be implicitly treated as an API request for changes. Instead, we should add an additional comment match for `API CHANGES REQUESTED` and use that to denote that a reviewer has requested changes to the API.

This PR implements this proposal, by removing checks for `REQUEST_CHANGES` reviews on the PR, and instead looking for `API CHANGES REQUESTED` text in PR review comments.

When this lands, there will be 3 comment strings that will change the API Review state:

* `API LGTM` - adds one sign-off for the PR's API changes
* `API CHANGES REQUESTED` - indicates that changes have been requested for the API. API Review workflow will not be approved while an `API CHANGES REQUESTED` is active.
* `API DECLINED` - indicates that the reviewer doesn't think this API should be added. API Review workflow will not be approved while an `API DECLINED` is active.

As has always been the case, the last review by each API WG member is evaluated by cation, so an `API CHANGES REQUESTED` or `API DECLINED` can be "cleared" by adding a follow-up `API LGTM` comment.