### PR TITLE
Add 'src' folder to Jest roots

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@ process.env.SPEC_RUNNING = '1';
 
 module.exports = {
   roots: [
-    '<rootDir>/spec'
+    '<rootDir>/spec',
+    '<rootDir>/src',
   ],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'


### PR DESCRIPTION
I was poking at the Jest CLI trying to get it to just run related tests when I change source files, but it was failing to find related tests.

According to [this](https://stackoverflow.com/a/70613739), the reason Jest can't find related tests is because the `src` folder isn't in the `roots` list in the Jest config.

This PR updates the `roots` config to include the `src` folder.

Before:

```
> yarn jest --findRelatedTests src/api-review-state.ts
yarn run v1.22.22
$ C:\Users\itsananderson\src\cation\node_modules\.bin\jest --findRelatedTests src/api-review-state.ts
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In C:\Users\itsananderson\src\cation
  47 files checked.
  testMatch:  - 0 matches
  testPathIgnorePatterns: spec\\utils.ts - 46 matches
  testRegex: (\\spec\\.*|(\.|\\)(test|spec))\.tsx?$ - 6 matches
Pattern: src\\api-review-state.ts - 0 matches
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After:

```
> yarn jest --findRelatedTests src/api-review-state.ts

... snip ...

Test Suites: 2 passed, 2 total
Tests:       35 passed, 35 total
Snapshots:   0 total
Time:        19.175 s, estimated 20 s
Ran all test suites related to files matching /src\\api-review-state.ts/i.
Done in 19.82s.
```