### PR TITLE
chore: convert JSDoc comments to TSDoc

### DIFF
--- a/src/24-hour-rule.ts
+++ b/src/24-hour-rule.ts
@@ -23,9 +23,7 @@ const CHECK_INTERVAL = 1000 * 60 * 5;
 type TimelineEvents = RestEndpointMethodTypes['issues']['listEventsForTimeline']['response'];
 
 /**
- *
- * @param {EventPayloads.WebhookPayloadPullRequestPullRequest} pr
- * @returns {number} a number representing the minimum open time for the PR
+ * @returns a number representing the minimum open time for the PR
  * based on  its semantic prefix in milliseconds
  */
 export const getMinimumOpenTime = (pr: PullRequest): number => {
@@ -42,10 +40,8 @@ export const getMinimumOpenTime = (pr: PullRequest): number => {
 };
 
 /**
- *
- * @param {Context['github']}  github An Octokit instance
- * @param {EventPayloads.WebhookPayloadPullRequestPullRequest} pr
- * @returns {number} a number representing the that cation should use as the
+ * @param github - An Octokit instance
+ * @returns a number representing the that cation should use as the
  * open time for the PR in milliseconds, taking draft status into account.
  */
 export const getPROpenedTime = async (

--- a/src/api-review-state.ts
+++ b/src/api-review-state.ts
@@ -38,7 +38,6 @@ export const isSemverMajorMinorLabel = (label: string) =>
 /**
  * Determines the PR readiness date depending on its semver label.
  *
- * @param {EventPayloads.WebhookPayloadPullRequestPullRequest} pr
  * @returns a date corresponding to the time that must elapse before a PR requiring
  *          API review is ready to be merged according to its semver label.
  */
@@ -314,9 +313,7 @@ export async function addOrUpdateAPIReviewCheck(octokit: Context['octokit'], pr:
 /**
  * Determines whether or not a PR is ready for merge depending on API WG Reviews.
  *
- * @param {Context['octokit']} octokit
- * @param {EventPayloads.WebhookPayloadPullRequestPullRequest} pr
- * @param {APIApprovalState} userApprovalState How many users have
+ * @param userApprovalState - How many users have
  *        approved/declined/requested changes for the PR.
  */
 export async function checkPRReadyForMerge(

--- a/src/utils/env-util.ts
+++ b/src/utils/env-util.ts
@@ -5,9 +5,9 @@ import { log } from './log-util';
  * Checks that a given environment variable exists, and returns
  * its value if it does. Conditionally throws an error on failure.
  *
- * @param {string} envVar - the environment variable to retrieve
- * @param {string} defaultValue - default value to use if no environment var is found
- * @returns {string} - the value of the env var being checked, or the default value if one is passed
+ * @param envVar - the environment variable to retrieve
+ * @param defaultValue - default value to use if no environment var is found
+ * @returns the value of the env var being checked, or the default value if one is passed
  */
 export function getEnvVar(envVar: string, defaultValue?: string): string {
   log('getEnvVar', LogLevel.INFO, `Fetching env var '${envVar}'`);

--- a/src/utils/log-util.ts
+++ b/src/utils/log-util.ts
@@ -3,9 +3,9 @@ import { LogLevel } from '../enums';
 /**
  * Logs information about different actions taking place to console.
  *
- * @param {string} functionName - the name of the function where the logging is happening
- * @param {LogLevel }logLevel - the severity level of the log
- * @param {any[]} message - the message to write to console
+ * @param functionName - the name of the function where the logging is happening
+ * @param logLevel - the severity level of the log
+ * @param message - the message to write to console
  */
 export const log = (functionName: string, logLevel: LogLevel, ...message: any[]) => {
   const output = `${functionName}: ${message}`;


### PR DESCRIPTION
Most of the "conversion" here is simply deleting `@param` and `@returns` which are only types, since they're redundant to the TS types, sometimes wrong, and TSDoc doesn't include types for obvious reasons.