### PR TITLE
chore: remove 'any' types

### DIFF
--- a/src/api-review-state.ts
+++ b/src/api-review-state.ts
@@ -45,8 +45,8 @@ export const isSemverMajorMinorLabel = (label: string) =>
 export const getPRReadyDate = (pr: PullRequest) => {
   let readyTime = new Date(pr.created_at).getTime();
 
-  if (!pr.labels.some((l: any) => l.name === API_SKIP_DELAY_LABEL)) {
-    const isMajorMinor = pr.labels.some((l: any) => isSemverMajorMinorLabel(l.name));
+  if (!pr.labels.some((l) => l.name === API_SKIP_DELAY_LABEL)) {
+    const isMajorMinor = pr.labels.some((l) => isSemverMajorMinorLabel(l.name));
     readyTime += isMajorMinor ? MINIMUM_MINOR_OPEN_TIME : MINIMUM_PATCH_OPEN_TIME;
   }
 

--- a/src/enforce-semver-labels.ts
+++ b/src/enforce-semver-labels.ts
@@ -23,7 +23,7 @@ export function setupSemverLabelEnforcement(probot: Probot) {
 
       log('setupSemverLabelEnforcement', LogLevel.INFO, `Checking #${pr.number} for semver label`);
 
-      const semverLabels = pr.labels.filter((l: any) => ALL_SEMVER_LABELS.includes(l.name));
+      const semverLabels = pr.labels.filter((l) => ALL_SEMVER_LABELS.includes(l.name));
       if (semverLabels.length === 0) {
         log('setupSemverLabelEnforcement', LogLevel.ERROR, `#${pr.number} is missing semver label`);
 

--- a/src/utils/log-util.ts
+++ b/src/utils/log-util.ts
@@ -7,7 +7,7 @@ import { LogLevel } from '../enums';
  * @param {LogLevel }logLevel - the severity level of the log
  * @param {any[]} message - the message to write to console
  */
-export const log = (functionName: string, logLevel: LogLevel, ...message: any[]) => {
+export const log = (functionName: string, logLevel: LogLevel, ...message: unknown[]) => {
   const output = `${functionName}: ${message}`;
 
   if (logLevel === LogLevel.INFO) {


### PR DESCRIPTION
These were probably needed in the past to work around shortcomings in the types, but now it looks like the types are accurate and we don't need to use `any`.