### PR TITLE
feat: account for draft status when handling API review

### DIFF
--- a/spec/fixtures/api-review-state/pull_request.converted_to_draft.json
+++ b/spec/fixtures/api-review-state/pull_request.converted_to_draft.json
@@ -1,0 +1,147 @@
+{
+  "action": "converted_to_draft",
+  "number": 26876,
+  "pull_request": {
+    "url": "https://api.github.com/repos/electron/electron/pulls/26876",
+    "id": 534054584,
+    "node_id": "MDExOlB1bGxSZXF1ZXN0NTM0MDU0NTg0",
+    "html_url": "https://github.com/electron/electron/pull/26876",
+    "diff_url": "https://github.com/electron/electron/pull/26876.diff",
+    "patch_url": "https://github.com/electron/electron/pull/26876.patch",
+    "issue_url": "https://api.github.com/repos/electron/electron/issues/26876",
+    "number": 26876,
+    "state": "open",
+    "locked": false,
+    "draft": true,
+    "title": "chore: fix JS linting",
+    "user": {
+      "login": "MarshallOfSound",
+      "id": 6634592,
+      "node_id": "MDQ6VXNlcjY2MzQ1OTI=",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/6634592?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/MarshallOfSound"
+    },
+    "body": "* Ensure --fix output is actually written to disk\r\n* Cache bust on lint.js file changes\r\n* Ensure CI does not use the linting cache\r\n\r\nNotes: no-notes",
+    "created_at": "2020-12-08T01:24:55Z",
+    "updated_at": "2020-12-08T01:24:55Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignee": null,
+    "labels": [
+      {
+        "id": 1034512799,
+        "node_id": "MDU6TGFiZWwxMDM0NTEyNzk5",
+        "url": "https://api.github.com/repos/electron/electron/labels/semver/major",
+        "name": "semver/minor",
+        "color": "6ac2dd",
+        "default": false,
+        "description": "backwards-compatible bug fixes"
+      },
+      {
+        "id": 1603621692,
+        "node_id": "MDU6TGFiZWwxNjAzNjIxNjky",
+        "url": "https://api.github.com/repos/electron/electron/labels/api-review/requested%20%F0%9F%97%B3",
+        "name": "api-review/requested 🗳",
+        "color": "c918ba",
+        "default": false,
+        "description": ""
+      }
+    ],
+    "head": {
+      "label": "electron:fix-lint-js",
+      "ref": "fix-lint-js",
+      "sha": "c6b1b7168ab850a47f856c4a30f7a441bede1117",
+      "user": {
+        "login": "electron",
+        "id": 13409222
+      },
+      "repo": {
+        "id": 9384267,
+        "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+        "name": "electron",
+        "full_name": "electron/electron",
+        "private": false,
+        "owner": {
+          "login": "electron",
+          "id": 13409222
+        }
+      }
+    },
+    "base": {
+      "label": "electron:main",
+      "ref": "main",
+      "sha": "c41b8d536b2d886abbe739374c0a46f99242a894",
+      "user": {
+        "login": "electron",
+        "id": 13409222,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+        "avatar_url": "https://avatars.githubusercontent.com/u/13409222?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/electron",
+        "html_url": "https://github.com/electron",
+        "followers_url": "https://api.github.com/users/electron/followers",
+        "following_url": "https://api.github.com/users/electron/following{/other_user}",
+        "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+        "organizations_url": "https://api.github.com/users/electron/orgs",
+        "repos_url": "https://api.github.com/users/electron/repos",
+        "events_url": "https://api.github.com/users/electron/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/electron/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 9384267,
+        "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+        "name": "electron",
+        "full_name": "electron/electron",
+        "default_branch": "main",
+        "private": false,
+        "owner": {
+          "login": "electron",
+          "id": 13409222,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+          "avatar_url": "https://avatars.githubusercontent.com/u/13409222?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/electron",
+          "html_url": "https://github.com/electron",
+          "followers_url": "https://api.github.com/users/electron/followers",
+          "following_url": "https://api.github.com/users/electron/following{/other_user}",
+          "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+          "organizations_url": "https://api.github.com/users/electron/orgs",
+          "repos_url": "https://api.github.com/users/electron/repos",
+          "events_url": "https://api.github.com/users/electron/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/electron/received_events",
+          "type": "Organization",
+          "site_admin": false
+        }
+      }
+    }
+  },
+  "repository": {
+    "id": 9384267,
+    "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+    "name": "electron",
+    "full_name": "electron/electron",
+    "private": false,
+    "owner": {
+      "login": "electron",
+      "id": 13409222
+    },
+    "license": {
+      "key": "mit",
+      "name": "MIT License",
+      "spdx_id": "MIT",
+      "url": "https://api.github.com/licenses/mit",
+      "node_id": "MDc6TGljZW5zZTEz"
+    }
+  },
+  "sender": {
+    "login": "electron"
+  }
+}

--- a/spec/fixtures/api-review-state/pull_request.ready_for_review.json
+++ b/spec/fixtures/api-review-state/pull_request.ready_for_review.json
@@ -1,0 +1,138 @@
+{
+  "action": "ready_for_review",
+  "number": 26876,
+  "pull_request": {
+    "url": "https://api.github.com/repos/electron/electron/pulls/26876",
+    "id": 534054584,
+    "node_id": "MDExOlB1bGxSZXF1ZXN0NTM0MDU0NTg0",
+    "html_url": "https://github.com/electron/electron/pull/26876",
+    "diff_url": "https://github.com/electron/electron/pull/26876.diff",
+    "patch_url": "https://github.com/electron/electron/pull/26876.patch",
+    "issue_url": "https://api.github.com/repos/electron/electron/issues/26876",
+    "number": 26876,
+    "state": "open",
+    "locked": false,
+    "draft": false,
+    "title": "chore: fix JS linting",
+    "user": {
+      "login": "MarshallOfSound",
+      "id": 6634592,
+      "node_id": "MDQ6VXNlcjY2MzQ1OTI=",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/6634592?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/MarshallOfSound"
+    },
+    "body": "* Ensure --fix output is actually written to disk\r\n* Cache bust on lint.js file changes\r\n* Ensure CI does not use the linting cache\r\n\r\nNotes: no-notes",
+    "created_at": "2020-12-08T01:24:55Z",
+    "updated_at": "2020-12-08T01:24:55Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignee": null,
+    "labels": [
+      {
+        "id": 1034512799,
+        "node_id": "MDU6TGFiZWwxMDM0NTEyNzk5",
+        "url": "https://api.github.com/repos/electron/electron/labels/semver/major",
+        "name": "semver/minor",
+        "color": "6ac2dd",
+        "default": false,
+        "description": "backwards-compatible bug fixes"
+      }
+    ],
+    "head": {
+      "label": "electron:fix-lint-js",
+      "ref": "fix-lint-js",
+      "sha": "c6b1b7168ab850a47f856c4a30f7a441bede1117",
+      "user": {
+        "login": "electron",
+        "id": 13409222
+      },
+      "repo": {
+        "id": 9384267,
+        "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+        "name": "electron",
+        "full_name": "electron/electron",
+        "private": false,
+        "owner": {
+          "login": "electron",
+          "id": 13409222
+        }
+      }
+    },
+    "base": {
+      "label": "electron:main",
+      "ref": "main",
+      "sha": "c41b8d536b2d886abbe739374c0a46f99242a894",
+      "user": {
+        "login": "electron",
+        "id": 13409222,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+        "avatar_url": "https://avatars.githubusercontent.com/u/13409222?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/electron",
+        "html_url": "https://github.com/electron",
+        "followers_url": "https://api.github.com/users/electron/followers",
+        "following_url": "https://api.github.com/users/electron/following{/other_user}",
+        "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+        "organizations_url": "https://api.github.com/users/electron/orgs",
+        "repos_url": "https://api.github.com/users/electron/repos",
+        "events_url": "https://api.github.com/users/electron/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/electron/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 9384267,
+        "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+        "name": "electron",
+        "full_name": "electron/electron",
+        "default_branch": "main",
+        "private": false,
+        "owner": {
+          "login": "electron",
+          "id": 13409222,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+          "avatar_url": "https://avatars.githubusercontent.com/u/13409222?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/electron",
+          "html_url": "https://github.com/electron",
+          "followers_url": "https://api.github.com/users/electron/followers",
+          "following_url": "https://api.github.com/users/electron/following{/other_user}",
+          "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+          "organizations_url": "https://api.github.com/users/electron/orgs",
+          "repos_url": "https://api.github.com/users/electron/repos",
+          "events_url": "https://api.github.com/users/electron/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/electron/received_events",
+          "type": "Organization",
+          "site_admin": false
+        }
+      }
+    }
+  },
+  "repository": {
+    "id": 9384267,
+    "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+    "name": "electron",
+    "full_name": "electron/electron",
+    "private": false,
+    "owner": {
+      "login": "electron",
+      "id": 13409222
+    },
+    "license": {
+      "key": "mit",
+      "name": "MIT License",
+      "spdx_id": "MIT",
+      "url": "https://api.github.com/licenses/mit",
+      "node_id": "MDc6TGljZW5zZTEz"
+    }
+  },
+  "sender": {
+    "login": "electron"
+  }
+}


### PR DESCRIPTION
Closes https://github.com/electron/cation/issues/172.

Cation shouldn't request API review automatically on a PR that's still in draft status. It should update labels accordingly if a PR is opened in draft, or if an open PR is converted in/out of draft.