### PR TITLE
chore: use Dependabot to update GitHub Actions deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 7
+  groups:
+    # Creates a separate PR for each non-security-related major update.
+    major-version-updates:
+      applies-to: "version-updates"
+      group-by: "dependency-name"
+      update-types: ["major"]
+
+    # Creates a single PR with all non-security-related minor/patch updates.
+    non-major-version-updates:
+      applies-to: "version-updates"
+      update-types: ["minor", "patch"]
+
+    # Creates a single PR with all security-related updates.
+    security-updates:
+      applies-to: "security-updates"
+      update-types: ["major", "minor", "patch"]


### PR DESCRIPTION
This has been our standard across the Ecosystem WG repos for a couple years now, let's adopt it here as well so that we stay up-to-date.